### PR TITLE
Export and restore board configuration

### DIFF
--- a/studio/Python/tinymovr/endpoints.py
+++ b/studio/Python/tinymovr/endpoints.py
@@ -50,7 +50,7 @@ Endpoints = {
         "ep_id": 0x005,
         "types": (DataType.UINT8, DataType.UINT16),
         "labels": ("id", "baud_rate"),
-        "save_map": ("id": "can/id", "baud_rate" : "can/baud_rate")
+        "ser_map": {"can": ("id", "baud_rate")}
     },
     "set_can_config":
     {
@@ -60,7 +60,7 @@ Endpoints = {
         "types": (DataType.UINT8, DataType.UINT16),
         "defaults": (0,),
         "labels": ("id", "baud_rate"),
-        "restore_map": {"id": "can/id", "baud_rate" : "can/baud_rate"}
+        "ser_map": {"can": ("id", "baud_rate")}
     },
     "set_state":
     {
@@ -119,7 +119,7 @@ Endpoints = {
         "ep_id": 0x00F,
         "types": (DataType.FLOAT, DataType.FLOAT),
         "labels": ("velocity", "current"),
-        "restore_map": {"velocity": "limits/velocity", "current": "limits/current"}
+        "ser_map": {"limits": ("velocity", "current")}
     },
     "Iphase":
     {
@@ -145,7 +145,7 @@ Endpoints = {
         "ep_id": 0x015,
         "types": (DataType.FLOAT, DataType.FLOAT),
         "labels": ("velocity", "current"),
-        "save_map": {"velocity": "limits/velocity", "current": "limits/current"}
+        "ser_map": {"limits": ("velocity", "current")}
     },
     "reset":
     {
@@ -167,7 +167,7 @@ Endpoints = {
         "ep_id": 0x018,
         "types": (DataType.FLOAT, DataType.FLOAT),
         "labels": ("position", "velocity"),
-        "save_map": {"position": "limits/position", "velocity": "limits/velocity"}
+        "ser_map": {"gains": ("position", "velocity")}
     },
     "set_gains":
     {
@@ -176,7 +176,7 @@ Endpoints = {
         "ep_id": 0x019,
         "types": (DataType.FLOAT, DataType.FLOAT),
         "labels": ("position", "velocity"),
-        "restore_map": {"position": "limits/position", "velocity": "limits/velocity"}
+        "ser_map": {"gains": ("position", "velocity")}
     },
     "device_info":
     {
@@ -212,6 +212,7 @@ Endpoints = {
         "type": "r",
         "ep_id": 0x01E,
         "types": (DataType.UINT8, DataType.UINT16, DataType.UINT8, DataType.UINT16, DataType.UINT16),
-        "labels": ("calibrated", "R", "pole_pairs", "L", "encoder_cpr")
+        "labels": ("calibrated", "R", "pole_pairs", "L", "encoder_cpr"),
+        "ser_map": {"motor": ("R", "L", "pole_pairs")}
     },
 }

--- a/studio/Python/tinymovr/endpoints.py
+++ b/studio/Python/tinymovr/endpoints.py
@@ -49,7 +49,8 @@ Endpoints = {
         "type": "r",
         "ep_id": 0x005,
         "types": (DataType.UINT8, DataType.UINT16),
-        "labels": ("id", "baud_rate")
+        "labels": ("id", "baud_rate"),
+        "save_map": ("id": "can/id", "baud_rate" : "can/baud_rate")
     },
     "set_can_config":
     {
@@ -58,7 +59,8 @@ Endpoints = {
         "ep_id": 0x006,
         "types": (DataType.UINT8, DataType.UINT16),
         "defaults": (0,),
-        "labels": ("id", "baud_rate")
+        "labels": ("id", "baud_rate"),
+        "restore_map": {"id": "can/id", "baud_rate" : "can/baud_rate"}
     },
     "set_state":
     {
@@ -116,7 +118,8 @@ Endpoints = {
         "type": "w",
         "ep_id": 0x00F,
         "types": (DataType.FLOAT, DataType.FLOAT),
-        "labels": ("velocity", "current")
+        "labels": ("velocity", "current"),
+        "restore_map": {"velocity": "limits/velocity", "current": "limits/current"}
     },
     "Iphase":
     {
@@ -141,7 +144,8 @@ Endpoints = {
         "type": "r",
         "ep_id": 0x015,
         "types": (DataType.FLOAT, DataType.FLOAT),
-        "labels": ("velocity", "current")
+        "labels": ("velocity", "current"),
+        "save_map": {"velocity": "limits/velocity", "current": "limits/current"}
     },
     "reset":
     {
@@ -162,7 +166,8 @@ Endpoints = {
         "type": "r",
         "ep_id": 0x018,
         "types": (DataType.FLOAT, DataType.FLOAT),
-        "labels": ("position", "velocity")
+        "labels": ("position", "velocity"),
+        "save_map": {"position": "limits/position", "velocity": "limits/velocity"}
     },
     "set_gains":
     {
@@ -170,7 +175,8 @@ Endpoints = {
         "type": "w",
         "ep_id": 0x019,
         "types": (DataType.FLOAT, DataType.FLOAT),
-        "labels": ("position", "velocity")
+        "labels": ("position", "velocity"),
+        "restore_map": {"position": "limits/position", "velocity": "limits/velocity"}
     },
     "device_info":
     {

--- a/studio/Python/tinymovr/tinymovr.py
+++ b/studio/Python/tinymovr/tinymovr.py
@@ -82,6 +82,18 @@ class Tinymovr:
     def current_control(self):
         self.set_state(2, 0)
 
+    def save_config_file(self, file_path):
+        '''
+        Save the board config to a file
+        '''
+        pass
+
+    def restore_config_file(self, file_path):
+        '''
+        Restore the board config from a file
+        '''
+        pass
+
     @property
     def encoder_cpr(self):
         if self._encoder_cpr < 2048:


### PR DESCRIPTION
This PR enables exporting and restoring of board configuration data. The data are defined as part of the CAN endpoints in `endpoints.py`.  

The relevant commands are tmx.export_config(fname) for exporting and tmx.restore_config(fname) for importing. 

Please note that the restored config merely updates the values in Tinymovr RAM, an additional call to tmx.save_config() is required after restoring to save the new configuration to NVM.