### PR TITLE
Change pwm timer clock divider to ACLK/4

### DIFF
--- a/firmware/src/adc/adc.c
+++ b/firmware/src/adc/adc.c
@@ -217,7 +217,7 @@ void ADC_DTSE_Init(void)
     PAC55XX_ADC->DTSETRIGENT0TO3.TRIG1CFGIDX = 12;                      // DTSE Trigger 1 Sequence Configuration Entry Index
     PAC55XX_ADC->DTSETRIGENT0TO3.TRIG1EDGE = ADCDTSE_TRIGEDGE_RISING;   // PWMA0 rising edge
 
-    pac5xxx_timer_a_ccctr1_value_set( (ACLK_FREQ_HZ/2/PWM_TIMER_FREQ) - 2);
+    pac5xxx_timer_a_ccctr1_value_set( (timer_freq_hz/2/PWM_FREQ_HZ) - 2);
 
     //===== Setup DTSE Sequence B (sense current) - Starts at Entry 12 =====
     pac5xxx_dtse_seq_config(12, ADC0, EMUX_AIO10, 0,           0);
@@ -250,7 +250,7 @@ PAC5XXX_RAMFUNC void ADC_GetPhaseCurrents(struct FloatTriplet *phc)
 PAC5XXX_RAMFUNC void ADC_UpdateMeasurements(void)
 {
     // TODO: Try doing below transformations in integer domain
-    const float I_phase_offset_k =  PWM_TIMER_PERIOD / config.I_phase_offset_tau;
+    const float I_phase_offset_k =  PWM_PERIOD_S / config.I_phase_offset_tau;
     adc.I_phase_offset.A += (((float)PAC55XX_ADC->DTSERES6.VAL * SHUNT_SCALING_FACTOR)
         - adc.I_phase_offset.A) * I_phase_offset_k;
     adc.I_phase_offset.B += (((float)PAC55XX_ADC->DTSERES8.VAL * SHUNT_SCALING_FACTOR)

--- a/firmware/src/common.h
+++ b/firmware/src/common.h
@@ -66,24 +66,24 @@
 #define PAC5XXX_ERROR   1
 #endif
 
-#define PWM_TIMER_PERIOD (1.0f / PWM_TIMER_FREQ)
+#define PWM_PERIOD_S                (1.0f / PWM_FREQ_HZ)
 
-#define READ_UINT16(address)                      (*((uint16_t *) address))
-#define READ_UINT32(address)                      (*((uint32_t *) address))
+#define READ_UINT16(address)        (*((uint16_t *) address))
+#define READ_UINT32(address)        (*((uint32_t *) address))
 
 #define ERROR_FLAG_MAX_SIZE 5u
 
-static const float one_by_sqrt3 = 0.57735026919f;
-static const float two_by_sqrt3 = 1.15470053838f;
-
 #define PI (3.141592f)
 
-static const float invtwopi=0.1591549f;
-static const float twopi=6.283185f;
-static const float threehalfpi=4.7123889f;
-static const float pi=PI;
-static const float halfpi=PI*0.5f;
-static const float quarterpi=PI*0.25f;
+static const float one_by_sqrt3 = 0.57735026919f;
+static const float two_by_sqrt3 = 1.15470053838f;
+static const float invtwopi = 0.1591549f;
+static const float twopi = 6.283185f;
+static const float threehalfpi = 4.7123889f;
+static const float pi = PI;
+static const float halfpi = PI*0.5f;
+static const float quarterpi = PI*0.25f;
+static const int32_t timer_freq_hz = ACLK_FREQ_HZ / (pow(2, TXCTL_PS_DIV));
 
 struct FloatTriplet
 {

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -17,28 +17,21 @@
 
 #define VERSION_MAJOR (0u)
 #define VERSION_MINOR (8u)
-#define VERSION_PATCH (2u)
+#define VERSION_PATCH (3u)
 
 /// TINYMOVR CONFIGURATION OPTIONS ///
 
 // Uncomment to disable live gate driver control
 // #define DRY_RUN
 
-// WARNING! PLEASE DO NOT ADJUST CLOCK DIVIDER YET!
-// LEAVE IT AT 1
-// ACLK Clock Divider
-// The ACLK clock is equal to SCLK / ACLK_PRESCALER
-// Higher ACLK_DIVIDER values mean less PWM resolution, but also
-// slightly lower power consumption.
-// Valid values are {1, 2, 3, 4, 5, 6, 7, 8}
-#define ACLK_DIVIDER				(1)
-#define ACLK_FREQ_HZ                (300000000/ACLK_DIVIDER)
+#define ACLK_FREQ_HZ                (300000000)
 #define HCLK_FREQ_HZ                (150000000)
 
-// PWM Timer Frequency (Hz).
-// Determines the PWM Timer Frequency by varying the
-// PWM timer base.
-#define PWM_TIMER_FREQ              (20000)
+// Timer clock divider
+#define TXCTL_PS_DIV                TXCTL_PS_DIV2
+
+// Desired PWM Frequency (Hz).
+#define PWM_FREQ_HZ              (20000)
 
 // Limits
 #define PWM_LIMIT                   (0.8f)
@@ -47,10 +40,10 @@
 #define VBUS_LOW_THRESHOLD          (11.0f)
 
 // Calibration
-#define CAL_R_LEN             (2 * PWM_TIMER_FREQ)
-#define CAL_L_LEN             (1 * PWM_TIMER_FREQ)
-#define CAL_OFFSET_LEN        (1 * PWM_TIMER_FREQ)
-#define CAL_DIR_LEN           (4 * PWM_TIMER_FREQ)
+#define CAL_R_LEN             (2 * PWM_FREQ_HZ)
+#define CAL_L_LEN             (1 * PWM_FREQ_HZ)
+#define CAL_OFFSET_LEN        (1 * PWM_FREQ_HZ)
+#define CAL_DIR_LEN           (4 * PWM_FREQ_HZ)
 
 #define CAL_PHASE_TURNS             8
 

--- a/firmware/src/controller/controller.c
+++ b/firmware/src/controller/controller.c
@@ -120,7 +120,7 @@ PAC5XXX_RAMFUNC void CLControlStep(void)
         float delta_vel = vel_setpoint - vel_estimate;
         // Velocity limiting will be done later on based on the estimate
         Iq_setpoint += (delta_vel * config.vel_gain) + state.vel_integrator_Iq;
-        state.vel_integrator_Iq += delta_vel * PWM_TIMER_PERIOD * config.vel_integrator_gain;
+        state.vel_integrator_Iq += delta_vel * PWM_PERIOD_S * config.vel_integrator_gain;
     }
     else
     {
@@ -162,8 +162,8 @@ PAC5XXX_RAMFUNC void CLControlStep(void)
     const float delta_Id = 0 - state.Id_meas;
     const float delta_Iq = Iq_setpoint - state.Iq_meas;
 
-    state.Id_integrator_Vd += delta_Id * PWM_TIMER_PERIOD * config.Id_integrator_gain;
-    state.Iq_integrator_Vq += delta_Iq * PWM_TIMER_PERIOD * config.Iq_integrator_gain;
+    state.Id_integrator_Vd += delta_Id * PWM_PERIOD_S * config.Id_integrator_gain;
+    state.Iq_integrator_Vq += delta_Iq * PWM_PERIOD_S * config.Iq_integrator_gain;
 
     const float Vd = (delta_Id * config.I_gain) + state.Id_integrator_Vd;
     const float Vq = (delta_Iq * config.I_gain) + state.Iq_integrator_Vq;

--- a/firmware/src/gatedriver/gatedriver.h
+++ b/firmware/src/gatedriver/gatedriver.h
@@ -38,17 +38,17 @@ extern PAC5XXX_RAMFUNC void GateDriver_SetDutyCycle(struct FloatTriplet *dc);
 //=============================================
 PAC5XXX_RAMFUNC static inline void m1_u_set_duty(float duty)
 {
-    uint16_t val = ((uint16_t)(duty * (ACLK_FREQ_HZ/PWM_TIMER_FREQ) )) >>1;
+    uint16_t val = ((uint16_t)(duty * (timer_freq_hz/PWM_FREQ_HZ) )) >>1;
     PAC55XX_TIMERA->CCTR4.CTR = val;
 }
 PAC5XXX_RAMFUNC static inline void m1_v_set_duty(float duty)
 {
-    uint16_t val = ((uint16_t)(duty * (ACLK_FREQ_HZ/PWM_TIMER_FREQ) )) >>1;
+    uint16_t val = ((uint16_t)(duty * (timer_freq_hz/PWM_FREQ_HZ) )) >>1;
     PAC55XX_TIMERA->CCTR5.CTR = val;
 }
 PAC5XXX_RAMFUNC static inline void m1_w_set_duty(float duty)
 {
-    uint16_t val = ((uint16_t)(duty * (ACLK_FREQ_HZ/PWM_TIMER_FREQ) )) >>1;
+    uint16_t val = ((uint16_t)(duty * (timer_freq_hz/PWM_FREQ_HZ) )) >>1;
     PAC55XX_TIMERA->CCTR6.CTR = val;
 }
 

--- a/firmware/src/motor/calibration.c
+++ b/firmware/src/motor/calibration.c
@@ -81,7 +81,7 @@ bool CalibrateInductance(void)
 	}
 #ifndef DRY_RUN
 	const float num_cycles = CAL_L_LEN / 2;
-	const float dI_by_dt = (I_high - I_low) / (PWM_TIMER_PERIOD * num_cycles);
+	const float dI_by_dt = (I_high - I_low) / (PWM_PERIOD_S * num_cycles);
 	const float L = CAL_V_INDUCTANCE / dI_by_dt;
 	if ((L <= MIN_PHASE_INDUCTANCE) || (L >= MAX_PHASE_INDUCTANCE))
 	{

--- a/firmware/src/observer/observer.c
+++ b/firmware/src/observer/observer.c
@@ -41,10 +41,10 @@ void Observer_Reset(void)
 
 PAC5XXX_RAMFUNC static inline void Observer_UpdatePosEstimate(int new_pos_meas)
 {
-	const float delta_pos_est = PWM_TIMER_PERIOD * state.vel_estimate;
+	const float delta_pos_est = PWM_PERIOD_S * state.vel_estimate;
 	const float delta_pos_meas = wrapf(new_pos_meas - state.pos_estimate, ENCODER_HALF_TICKS);
 	const float delta_pos_error = delta_pos_meas - delta_pos_est;
-	const float incr_pos = delta_pos_est + (PWM_TIMER_PERIOD * config.kp * delta_pos_error);
+	const float incr_pos = delta_pos_est + (PWM_PERIOD_S * config.kp * delta_pos_error);
 	state.pos_estimate += incr_pos;
 	state.pos_estimate_wrapped = wrapf(state.pos_estimate_wrapped + incr_pos, ENCODER_HALF_TICKS);
 	if (state.pos_estimate > config.sector_half_interval)
@@ -61,7 +61,7 @@ PAC5XXX_RAMFUNC static inline void Observer_UpdatePosEstimate(int new_pos_meas)
 	{
 		// No action
 	}
-	state.vel_estimate += PWM_TIMER_PERIOD * config.ki * delta_pos_error;
+	state.vel_estimate += PWM_PERIOD_S * config.ki * delta_pos_error;
 }
 
 PAC5XXX_RAMFUNC float Observer_GetBandwidth(void)

--- a/firmware/src/system/system.c
+++ b/firmware/src/system/system.c
@@ -43,7 +43,7 @@ void system_init(void)
 
     // Configure SCLK=PLLCLK=300 MHz, HCLK=150 MHz, PCLK=150 MHz, ACLK=300 MHz and WaitStates;  Use default PCLKDIV=1
     PAC55XX_SCC->CCSCTL.HCLKDIV = CCSCTL_HCLKDIV_DIV2;          // HCLK = 150 MHz = SCLK/2; when SCLK = PLLCLK
-    PAC55XX_SCC->CCSCTL.ACLKDIV = (ACLK_DIVIDER - 1);
+    PAC55XX_SCC->CCSCTL.ACLKDIV = CCSCTL_ACLKDIV_DIV1;
     PAC55XX_MEMCTL->MEMCTL.WSTATE = 5 + 1;                      // Flash = 150/25 = 6 clocks = 5 WS; So, need 5 + 1 Extra WS
     PAC55XX_SCC->CCSCTL.SCLKMUXSEL = CCSCTL_SCLK_PLLCLK;        // SCLK = PLLCLK
 

--- a/firmware/src/timer/timer.c
+++ b/firmware/src/timer/timer.c
@@ -21,8 +21,8 @@
 void Timer_Init(void)
 {
     // Configure Timer A Controls
-    pac5xxx_timer_clock_config(TimerA, TXCTL_CS_ACLK, TXCTL_PS_DIV1);                   // Configure timer clock input for ACLK, /1 divider
-    pac5xxx_timer_base_config(TimerA, (ACLK_FREQ_HZ/2/PWM_TIMER_FREQ), AUTO_RELOAD,
+    pac5xxx_timer_clock_config(TimerA, TXCTL_CS_ACLK, TXCTL_PS_DIV);                   // Configure timer clock input for ACLK, divider
+    pac5xxx_timer_base_config(TimerA, (timer_freq_hz/2/PWM_FREQ_HZ), AUTO_RELOAD,
             TxCTL_MODE_UPDOWN, TIMER_SLAVE_SYNC_DISABLE);                               // Configure timer frequency and count mode
 
     // Configure Dead time generators


### PR DESCRIPTION
Results in additional ~15% reduction in idle power consumption.