### PR TITLE
Optimize encoder reads

### DIFF
--- a/firmware/src/encoder/encoder.c
+++ b/firmware/src/encoder/encoder.c
@@ -31,7 +31,13 @@ void MA_Init(void)
 {
     ssp_init(SSPD, SSP_MS_MASTER, 0, 0); // Mode 0
     system_delay_us(16000); // ensure 16ms sensor startup time as per the datasheet
+    MA_QueueAngleCommand();
     MA_UpdateAngle(false);
+}
+
+PAC5XXX_RAMFUNC void MA_QueueAngleCommand(void)
+{
+	ssp_write_one(SSPD, MA_CMD_ANGLE);
 }
 
 PAC5XXX_RAMFUNC int16_t MA_GetAngle(void)
@@ -41,7 +47,7 @@ PAC5XXX_RAMFUNC int16_t MA_GetAngle(void)
 
 PAC5XXX_RAMFUNC void MA_UpdateAngle(bool check_error)
 {
-	ssp_write_one(SSPD, MA_CMD_ANGLE);
+	//ssp_write_one(SSPD, MA_CMD_ANGLE);
     while (!PAC55XX_SSPD->STAT.RNE) {}
     const int16_t angle = (PAC55XX_SSPD->DAT.DATA) >> 3;
 

--- a/firmware/src/encoder/encoder.h
+++ b/firmware/src/encoder/encoder.h
@@ -42,6 +42,7 @@ struct MA702State
 };
 
 void MA_Init(void);
+PAC5XXX_RAMFUNC void MA_QueueAngleCommand(void);
 PAC5XXX_RAMFUNC int16_t MA_GetAngle(void);
 PAC5XXX_RAMFUNC void MA_UpdateAngle(bool check_error);
 

--- a/firmware/src/scheduler/scheduler.c
+++ b/firmware/src/scheduler/scheduler.c
@@ -66,6 +66,7 @@ void WaitForControlLoopInterrupt(void)
 	state.busy_loop_start = DWT->CYCCNT;
 	// We have to service the control loop by updating
 	// current measurements and encoder estimates.
+	MA_QueueAngleCommand();
 	ADC_UpdateMeasurements();
 	MA_UpdateAngle(true);
 	Observer_UpdateEstimates();


### PR DESCRIPTION
This PR schedules encoder reads to occur right before processing measured ADC data (ADC measurements have already finished by that time), and then performs a readout right after the ADC processing finishes. This saves roughly around 100 CPU cycles from waiting for the SPI to respond.

